### PR TITLE
fix: file names not wrapping

### DIFF
--- a/client/src/pages/home/Home.css
+++ b/client/src/pages/home/Home.css
@@ -175,7 +175,7 @@
 
 .glass-file-name {
     max-width: 60%;
-
+    overflow-wrap: break-word;
 }
 
 .glass-row .right {


### PR DESCRIPTION
Previous behavior:
![Screenshot 2022-10-01 160640](https://user-images.githubusercontent.com/63467479/193405636-7256aa2e-9525-4094-91cf-35c46dc6c7bd.png)

Now:
![Screenshot 2022-10-01 160653](https://user-images.githubusercontent.com/63467479/193405644-e392696b-6c71-4935-8cfc-3146369bb74d.png)
