### PR TITLE
Fix margin in File page for mobile devices

### DIFF
--- a/client/src/components/file-desc/Desc.css
+++ b/client/src/components/file-desc/Desc.css
@@ -254,8 +254,32 @@
     }
 }
 
+@media  screen and (max-width: 515px) {
+    .file-actions{
+        display: grid;
+        gap: 1rem
+    }
+}
+
+@media  screen and (max-width: 880px) {
+    .glass-file-desc{
+        box-sizing: border-box;
+        max-width: 80%;
+    }
+    .outline-con{
+        max-width: 80%;                                                                         
+    }
+}
+
 @media screen and (max-width: 1000px){
     .glass-file-desc{
         box-sizing: border-box;
+    }
+
+}
+
+@media screen and (max-width: 1440px) {
+    .file-name{
+        word-break: break-all;
     }
 }


### PR DESCRIPTION
# Description

The pull request fixes the margin setup for divs in the File section. Some screenshots about the fix

Width up to 880px

![image](https://user-images.githubusercontent.com/48018975/193455593-48fcbe83-f00b-4592-b79f-4237f9ae37fc.png)

Width up to 515px (the icon div containter is now showing properly)

![image](https://user-images.githubusercontent.com/48018975/193455660-d6e39f1c-7b88-4d0d-9d61-79d0aab0655e.png)

Fixes #21 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules