### PR TITLE
Fix: Deleting a file actually deletes all files

### DIFF
--- a/client/src/components/file-desc/Desc.jsx
+++ b/client/src/components/file-desc/Desc.jsx
@@ -86,7 +86,7 @@ function Desc() {
 
   function deleteFile(t) {
     toast.dismiss(t.id);
-    Axios.patch(`${process.env.REACT_APP_SERVER_URL}/api/user/deleteFile/${file?.cid}`, {}, { headers: { Authorization: 'Bearer ' + window.localStorage.getItem("didToken") } }).then(res => {
+    Axios.patch(`${process.env.REACT_APP_SERVER_URL}/api/user/deleteFile/${file?._id}`, {}, { headers: { Authorization: 'Bearer ' + window.localStorage.getItem("didToken") } }).then(res => {
       console.log(res.data.message);
       toast(res.data.message, {
         icon: '✅',

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -113,7 +113,7 @@ router.patch(
 );
 
 router.patch(
-  '/api/user/deleteFile/:cid',
+  '/api/user/deleteFile/:id',
   authMiddleware,
   async (req, res, next) => {
     console.log('Delete route called!');
@@ -121,14 +121,14 @@ router.patch(
       req.headers.authorization.substring(7)
     );
     const magic_id = metadata.issuer;
-    const { cid } = req.params;
-    if (!magic_id || !cid) {
+    const { id:_id } = req.params;
+    if (!magic_id || !_id) {
       return next(new AppError('Missing required fields', 400));
     }
     try {
       await User.updateOne(
-        { magic_id, files: { $elemMatch: { cid } } },
-        { $pull: { files: { cid } } }
+        { magic_id, files: { $elemMatch: { _id } } },
+        { $pull: { files: { _id } } }
       );
       return res.status(200).json({ message: 'File deleted successfully!' });
     } catch (err) {


### PR DESCRIPTION
# Description
Deleting a file actually deletes all files with same `cid`. Have performed the delete operation using `_id` which is uniquely generated for all files by MongoDB. So doing this removes only the file that is actually expected to be deleted.

Fixes #105 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
