### PR TITLE
fix: landing page 3D globe memory leak

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,7 +23,7 @@
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.1",
-        "react-globe.gl": "^2.22.4",
+        "react-globe.gl": "^2.22.10",
         "react-helmet": "^6.1.0",
         "react-hot-toast": "^2.2.0",
         "react-icons": "^4.4.0",
@@ -7159,9 +7159,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -7197,9 +7197,9 @@
       }
     },
     "node_modules/d3-geo": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
-      "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -7248,9 +7248,9 @@
       }
     },
     "node_modules/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -9764,9 +9764,9 @@
       }
     },
     "node_modules/globe.gl": {
-      "version": "2.26.6",
-      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.26.6.tgz",
-      "integrity": "sha512-epixEtONQm4/30MqCEPp8uqxvpAGDSXH77VL/ykxNET5cP0Xw4pwC3JF9JJ3VOZzkg4MUlZ7gSPit1lNkWDklQ==",
+      "version": "2.26.12",
+      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.26.12.tgz",
+      "integrity": "sha512-IwCZ2qoWcv0SxEGoIn6AKa/56ybMXqCAW7R64LjUnOwW7flWtYlBLm2YuOkHCya8GhJLK8iDzkB6HeAHqIYylQ==",
       "dependencies": {
         "@tweenjs/tween.js": "^18.6",
         "accessor-fn": "1",
@@ -16397,9 +16397,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-globe.gl": {
-      "version": "2.22.4",
-      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.22.4.tgz",
-      "integrity": "sha512-1Ikb7lCUTCvQeEwzDF0hhxiecG6UbCm/DwidLT2liibMePvhbq18u5uAC9QfIDYjzqbbLu6hJwNvQXivOZ4nYw==",
+      "version": "2.22.10",
+      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.22.10.tgz",
+      "integrity": "sha512-WiOXOORIe8BQeqwLu6cdHoAQYdmyJE+AJPUxrtUjKHShz9PyNfd4NwK2ZyF1gZ9V1T7Z0/oPyaAMRGWeRYPVIA==",
       "dependencies": {
         "globe.gl": "^2.26",
         "prop-types": "^15.8",
@@ -16452,9 +16452,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-kapsule": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.2.5.tgz",
-      "integrity": "sha512-79fLQAx0GBRsXsZMbayI+to//RrBkbxPH9//wZgmCp32lTefMShrncOpHg59BlWzEana9c3tPAltv6j9nI2iiQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.2.6.tgz",
+      "integrity": "sha512-OUfvKeXSwpwVcGhyUWK6XaStEAA/KWFvlRAo/maS+GWhp7X0mSMbuZ/5jBACXhTFNGqWHf5yyt+LURiWA77HfA==",
       "dependencies": {
         "fromentries": "^1.3.2",
         "jerrypick": "^1.0.5"
@@ -18469,9 +18469,9 @@
       "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
     },
     "node_modules/three-conic-polygon-geometry": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-1.5.2.tgz",
-      "integrity": "sha512-CERaIUH7TjvwlhIGePQkehPeAXnrJsAm0UyIgGZOirt+kuhFLDgNpTXzh5Djvj+BMGZ4G69llTQkQjLcPdLy4w==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-1.5.4.tgz",
+      "integrity": "sha512-sU0hi1CtEJh0dKFV25hTqFxVojYAYj+K2HA0+aIWifOc4qLacbj1HQ4hFSd7Fx0EjslBasoPHe9kdmib8NbhWw==",
       "dependencies": {
         "@turf/boolean-point-in-polygon": "^6.5",
         "d3-array": "1 - 3",
@@ -18486,9 +18486,9 @@
       }
     },
     "node_modules/three-fatline": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/three-fatline/-/three-fatline-0.5.3.tgz",
-      "integrity": "sha512-oKpBkodXLim6STcM6mbdZT4i0PwsXnjHzsEo6I0OO7HHkbkV1XJ+mvmuMDwmfAxT5PjJDbQhvrB1lfoGjEQdUg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/three-fatline/-/three-fatline-0.5.4.tgz",
+      "integrity": "sha512-Pa4AiVOzoEsC+sUxUuGdFKOe2beS8AcB3upy8ppaCoz2ZQCtCNO6hnLxLQlkcrmw9XnTMaGzcAS2zGulbw4QXA==",
       "peerDependencies": {
         "three": ">=0.84.0"
       }
@@ -18506,9 +18506,9 @@
       }
     },
     "node_modules/three-globe": {
-      "version": "2.24.8",
-      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.24.8.tgz",
-      "integrity": "sha512-jpNq4lOVH41Fqfd0TpquC3ElPLAshgRDkPhMZKO+Hd0R0jbRJ6PhhRgOs70bY0EkJusgwf6VW5gZZphAwL8T7g==",
+      "version": "2.24.13",
+      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.24.13.tgz",
+      "integrity": "sha512-aYvXBV4T5OV1j06JTHeLo3XChhoW7ZsYg0at7yWWc8MYpow9BlSRFZsAC6yVfmxekjqfarnxuJCZzZ7geHM79g==",
       "dependencies": {
         "@tweenjs/tween.js": "18",
         "accessor-fn": "1",
@@ -18524,16 +18524,16 @@
         "three-conic-polygon-geometry": "^1.5",
         "three-fatline": "^0.5",
         "three-geojson-geometry": "^1.1",
-        "tinycolor2": "^1.4"
+        "tinycolor2": "^1.5"
       },
       "peerDependencies": {
-        "three": ">=0.109.0"
+        "three": ">=0.125.0"
       }
     },
     "node_modules/three-render-objects": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.27.4.tgz",
-      "integrity": "sha512-rPFh1eE3NjErTe6bDZZIZQeIfj0BlW5vyeOuDIievNyszrpQBs5qcvTZEomCO+/nCM5tb3ZFANA8HQWr9wjDuw==",
+      "version": "1.27.8",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.27.8.tgz",
+      "integrity": "sha512-ufnSu2AT1bPcg1NX91SS3hz6OxJcpNUGOjNtarCmzNmRkVlhc/PZJHcF4aPU6cy8X7R3bQfGRgUdh75kpAyTgg==",
       "dependencies": {
         "@tweenjs/tween.js": "18",
         "accessor-fn": "1",
@@ -18585,12 +18585,9 @@
       }
     },
     "node_modules/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-      "engines": {
-        "node": "*"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.5.2.tgz",
+      "integrity": "sha512-h80m9GPFGbcLzZByXlNSEhp1gf8Dy+VX/2JCGUZsWLo7lV1mnE/XlxGYgRBoMLJh1lIDXP0EMC4RPTjlRaV+Bg=="
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",
@@ -25980,9 +25977,9 @@
       }
     },
     "d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
       "requires": {
         "internmap": "1 - 2"
       }
@@ -26006,9 +26003,9 @@
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-geo": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
-      "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "requires": {
         "d3-array": "2.5.0 - 3"
       }
@@ -26045,9 +26042,9 @@
       }
     },
     "d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "requires": {
         "d3-array": "2 - 3"
       }
@@ -27929,9 +27926,9 @@
       }
     },
     "globe.gl": {
-      "version": "2.26.6",
-      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.26.6.tgz",
-      "integrity": "sha512-epixEtONQm4/30MqCEPp8uqxvpAGDSXH77VL/ykxNET5cP0Xw4pwC3JF9JJ3VOZzkg4MUlZ7gSPit1lNkWDklQ==",
+      "version": "2.26.12",
+      "resolved": "https://registry.npmjs.org/globe.gl/-/globe.gl-2.26.12.tgz",
+      "integrity": "sha512-IwCZ2qoWcv0SxEGoIn6AKa/56ybMXqCAW7R64LjUnOwW7flWtYlBLm2YuOkHCya8GhJLK8iDzkB6HeAHqIYylQ==",
       "requires": {
         "@tweenjs/tween.js": "^18.6",
         "accessor-fn": "1",
@@ -32799,9 +32796,9 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-globe.gl": {
-      "version": "2.22.4",
-      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.22.4.tgz",
-      "integrity": "sha512-1Ikb7lCUTCvQeEwzDF0hhxiecG6UbCm/DwidLT2liibMePvhbq18u5uAC9QfIDYjzqbbLu6hJwNvQXivOZ4nYw==",
+      "version": "2.22.10",
+      "resolved": "https://registry.npmjs.org/react-globe.gl/-/react-globe.gl-2.22.10.tgz",
+      "integrity": "sha512-WiOXOORIe8BQeqwLu6cdHoAQYdmyJE+AJPUxrtUjKHShz9PyNfd4NwK2ZyF1gZ9V1T7Z0/oPyaAMRGWeRYPVIA==",
       "requires": {
         "globe.gl": "^2.26",
         "prop-types": "^15.8",
@@ -32839,9 +32836,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-kapsule": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.2.5.tgz",
-      "integrity": "sha512-79fLQAx0GBRsXsZMbayI+to//RrBkbxPH9//wZgmCp32lTefMShrncOpHg59BlWzEana9c3tPAltv6j9nI2iiQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.2.6.tgz",
+      "integrity": "sha512-OUfvKeXSwpwVcGhyUWK6XaStEAA/KWFvlRAo/maS+GWhp7X0mSMbuZ/5jBACXhTFNGqWHf5yyt+LURiWA77HfA==",
       "requires": {
         "fromentries": "^1.3.2",
         "jerrypick": "^1.0.5"
@@ -34334,9 +34331,9 @@
       "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
     },
     "three-conic-polygon-geometry": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-1.5.2.tgz",
-      "integrity": "sha512-CERaIUH7TjvwlhIGePQkehPeAXnrJsAm0UyIgGZOirt+kuhFLDgNpTXzh5Djvj+BMGZ4G69llTQkQjLcPdLy4w==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/three-conic-polygon-geometry/-/three-conic-polygon-geometry-1.5.4.tgz",
+      "integrity": "sha512-sU0hi1CtEJh0dKFV25hTqFxVojYAYj+K2HA0+aIWifOc4qLacbj1HQ4hFSd7Fx0EjslBasoPHe9kdmib8NbhWw==",
       "requires": {
         "@turf/boolean-point-in-polygon": "^6.5",
         "d3-array": "1 - 3",
@@ -34348,9 +34345,9 @@
       }
     },
     "three-fatline": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/three-fatline/-/three-fatline-0.5.3.tgz",
-      "integrity": "sha512-oKpBkodXLim6STcM6mbdZT4i0PwsXnjHzsEo6I0OO7HHkbkV1XJ+mvmuMDwmfAxT5PjJDbQhvrB1lfoGjEQdUg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/three-fatline/-/three-fatline-0.5.4.tgz",
+      "integrity": "sha512-Pa4AiVOzoEsC+sUxUuGdFKOe2beS8AcB3upy8ppaCoz2ZQCtCNO6hnLxLQlkcrmw9XnTMaGzcAS2zGulbw4QXA==",
       "requires": {}
     },
     "three-geojson-geometry": {
@@ -34363,9 +34360,9 @@
       }
     },
     "three-globe": {
-      "version": "2.24.8",
-      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.24.8.tgz",
-      "integrity": "sha512-jpNq4lOVH41Fqfd0TpquC3ElPLAshgRDkPhMZKO+Hd0R0jbRJ6PhhRgOs70bY0EkJusgwf6VW5gZZphAwL8T7g==",
+      "version": "2.24.13",
+      "resolved": "https://registry.npmjs.org/three-globe/-/three-globe-2.24.13.tgz",
+      "integrity": "sha512-aYvXBV4T5OV1j06JTHeLo3XChhoW7ZsYg0at7yWWc8MYpow9BlSRFZsAC6yVfmxekjqfarnxuJCZzZ7geHM79g==",
       "requires": {
         "@tweenjs/tween.js": "18",
         "accessor-fn": "1",
@@ -34381,13 +34378,13 @@
         "three-conic-polygon-geometry": "^1.5",
         "three-fatline": "^0.5",
         "three-geojson-geometry": "^1.1",
-        "tinycolor2": "^1.4"
+        "tinycolor2": "^1.5"
       }
     },
     "three-render-objects": {
-      "version": "1.27.4",
-      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.27.4.tgz",
-      "integrity": "sha512-rPFh1eE3NjErTe6bDZZIZQeIfj0BlW5vyeOuDIievNyszrpQBs5qcvTZEomCO+/nCM5tb3ZFANA8HQWr9wjDuw==",
+      "version": "1.27.8",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.27.8.tgz",
+      "integrity": "sha512-ufnSu2AT1bPcg1NX91SS3hz6OxJcpNUGOjNtarCmzNmRkVlhc/PZJHcF4aPU6cy8X7R3bQfGRgUdh75kpAyTgg==",
       "requires": {
         "@tweenjs/tween.js": "18",
         "accessor-fn": "1",
@@ -34430,9 +34427,9 @@
       "integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA=="
     },
     "tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.5.2.tgz",
+      "integrity": "sha512-h80m9GPFGbcLzZByXlNSEhp1gf8Dy+VX/2JCGUZsWLo7lV1mnE/XlxGYgRBoMLJh1lIDXP0EMC4RPTjlRaV+Bg=="
     },
     "tippy.js": {
       "version": "6.3.7",

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.1",
-    "react-globe.gl": "^2.22.4",
+    "react-globe.gl": "^2.22.10",
     "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.2.0",
     "react-icons": "^4.4.0",


### PR DESCRIPTION
# Description

Memory leak caused by three-globe library has been fixed in a new release. Upgraded react-globe.gl to use the new version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules